### PR TITLE
Update eslint-plugin-react to 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
   "dependencies": {
     "babel-eslint": "^6.1.2",
     "eslint": "^2.13.1",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint-plugin-react": "^6.0.0"
   },
   "peerDependencies": {
     "eslint": "^2.13.1",
     "babel-eslint": "^6.1.2",
-    "eslint-plugin-react": "^5.2.2"
+    "eslint-plugin-react": "^6.0.0"
   }
 }


### PR DESCRIPTION
This PR was motivated specifically by some improved options for `no-multi-comp` which allows stateless components to be ignored. This allows us to continue using helper functions in a stateless component without the linter thinking we're trying to define multiple components in one file:

``` javascript
function MyStatelessComponent({ title, items }) {
  // ...
  const renderItems = () => {
    return items.map((item) => <li>{item.name}</li>) // no-multi-comp v5 thinks this is a second component definition in the same file
  };

  return (
    <div>
      <h1>{title}</h1>
      <ul>
        {renderItems()}
      </ul>
    </div>
  );
}
```
